### PR TITLE
feat: add categories page with server-side loading and display of cat…

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -6,7 +6,7 @@ declare global {
 		interface Locals {
 			user: User & { accessToken: string };
 		}
-		// interface PageData {}
+		interface PageData {}
 		// interface PageState {}
 		// interface Platform {}
 	}

--- a/src/lib/components/dashboard/dashboard-sidebar.svelte
+++ b/src/lib/components/dashboard/dashboard-sidebar.svelte
@@ -1,24 +1,19 @@
 <script lang="ts">
 	import CameraIcon from '@tabler/icons-svelte/icons/camera';
-	import ChartBarIcon from '@tabler/icons-svelte/icons/chart-bar';
 	import DashboardIcon from '@tabler/icons-svelte/icons/dashboard';
 	import DatabaseIcon from '@tabler/icons-svelte/icons/database';
 	import FileAiIcon from '@tabler/icons-svelte/icons/file-ai';
 	import FileDescriptionIcon from '@tabler/icons-svelte/icons/file-description';
 	import FileWordIcon from '@tabler/icons-svelte/icons/file-word';
-	import FolderIcon from '@tabler/icons-svelte/icons/folder';
 	import HelpIcon from '@tabler/icons-svelte/icons/help';
 	import InnerShadowTopIcon from '@tabler/icons-svelte/icons/inner-shadow-top';
-	import ListDetailsIcon from '@tabler/icons-svelte/icons/list-details';
 	import ReportIcon from '@tabler/icons-svelte/icons/report';
 	import SearchIcon from '@tabler/icons-svelte/icons/search';
 	import SettingsIcon from '@tabler/icons-svelte/icons/settings';
-	import UsersIcon from '@tabler/icons-svelte/icons/users';
+	import Category from '@tabler/icons-svelte/icons/category';
 	import NavMain from './nav-main.svelte';
-	import NavSecondary from './nav-secondary.svelte';
 	import NavUser from './nav-user.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
-	import type { ComponentProps } from 'svelte';
 	import { base } from '$app/paths';
 
 	const data = {
@@ -38,6 +33,11 @@
 				title: 'Insight',
 				url: '/dashboard/insight',
 				icon: DashboardIcon
+			},
+			{
+				title: 'Categories',
+				url: '/dashboard/categories',
+				icon: Category
 			}
 			// {
 			// 	title: 'Lifecycle',

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -6,3 +6,5 @@ export const VERIFY_ACCOUNT_URL = PRIVATE_BACKEND_URL + '/auth/verify-account';
 export const VERIFY_TOKEN_URL = PRIVATE_BACKEND_URL + '/auth/verify-token';
 export const USER_INFO_URL = PRIVATE_BACKEND_URL + '/auth/me';
 export const REFRESH_TOKEN_URL = PRIVATE_BACKEND_URL + '/auth/refresh-token';
+
+export const CATEGORIES_URL = PRIVATE_BACKEND_URL + '/categories';

--- a/src/routes/(dashboard)/dashboard/categories/+page.server.ts
+++ b/src/routes/(dashboard)/dashboard/categories/+page.server.ts
@@ -1,0 +1,10 @@
+import { CATEGORIES_URL } from '$lib/urls';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({}) => {
+	try {
+		const categoriesResponse = await fetch(CATEGORIES_URL);
+		const categories: Page<Category> = await categoriesResponse.json();
+		return { categories };
+	} catch (error) {}
+};

--- a/src/routes/(dashboard)/dashboard/categories/+page.svelte
+++ b/src/routes/(dashboard)/dashboard/categories/+page.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import type { PageProps } from './$types';
+
+	let { data }: PageProps = $props();
+</script>
+
+<pre class="pre">
+    {JSON.stringify(data.categories, null, 2)}
+</pre>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -14,3 +14,43 @@ interface User {
 	createdAt: string;
 	updatedAt: string;
 }
+
+type Category = {
+	id: string;
+	title: string;
+	description: string;
+	image: string | null;
+	createdAt: string;
+	updatedAt: string;
+};
+
+type Pageable = {
+	pageNumber: number;
+	pageSize: number;
+	sort: {
+		sorted: boolean;
+		unsorted: boolean;
+		empty: boolean;
+	};
+	offset: number;
+	paged: boolean;
+	unpaged: boolean;
+};
+
+type Page<T> = {
+	content: T[];
+	pageable: Pageable;
+	totalPages: number;
+	totalElements: number;
+	last: boolean;
+	size: number;
+	number: number;
+	sort: {
+		sorted: boolean;
+		unsorted: boolean;
+		empty: boolean;
+	};
+	numberOfElements: number;
+	first: boolean;
+	empty: boolean;
+};


### PR DESCRIPTION
This pull request introduces a new "Categories" feature to the dashboard, including updates to the sidebar, backend URL definitions, and new routes for server-side and client-side rendering. The most important changes are the addition of the "Categories" section in the dashboard sidebar and the setup of backend and frontend functionality to support it.

### Dashboard Sidebar Updates:
* Added a new "Categories" section to the dashboard sidebar, including its title, URL, and associated icon (`Category`). [[1]](diffhunk://#diff-c3f3768388e65e213d68df0920180ee7be0a5a3f5e83f081137866bc9de82830L3-L21) [[2]](diffhunk://#diff-c3f3768388e65e213d68df0920180ee7be0a5a3f5e83f081137866bc9de82830R36-R40)

### Backend URL Definitions:
* Defined a new constant `CATEGORIES_URL` pointing to the backend endpoint for categories (`PRIVATE_BACKEND_URL + '/categories'`).

### Server-side Rendering:
* Created a new server-side route (`+page.server.ts`) to fetch categories data from the backend using the `CATEGORIES_URL`.

### Client-side Rendering:
* Added a new client-side route (`+page.svelte`) to display the fetched categories data in a JSON format for debugging purposes.…egories