### PR TITLE
hotfix: update article management actions and forms to reflect articl…

### DIFF
--- a/src/routes/(dashboard)/dashboard/articles/+page.server.ts
+++ b/src/routes/(dashboard)/dashboard/articles/+page.server.ts
@@ -1,5 +1,4 @@
-import { ARTICLES_URL, CATEGORIES_URL } from '$lib/urls';
-import { success } from 'zod/v4';
+import { ARTICLES_URL } from '$lib/urls';
 import type { PageServerLoad, Actions } from './$types';
 
 export const load: PageServerLoad = async ({}) => {
@@ -11,7 +10,7 @@ export const load: PageServerLoad = async ({}) => {
 };
 
 export const actions: Actions = {
-	createCategory: async ({ request, fetch }) => {
+	createArticle: async ({ request, fetch }) => {
 		const formData = await request.formData();
 
 		// Form validation
@@ -37,7 +36,7 @@ export const actions: Actions = {
 		// categoryFormData.append('description', description.trim());
 		// categoryFormData.append('image', description.trim());
 
-		const createCategoryResponse = await fetch(CATEGORIES_URL, {
+		const createCategoryResponse = await fetch(ARTICLES_URL, {
 			method: 'post',
 			body: formData
 		});
@@ -51,15 +50,15 @@ export const actions: Actions = {
 		}
 	},
 
-	deleteCategory: async ({ request, fetch, locals }) => {
-		const id = (await request.formData()).get('categoryId');
+	deleteArticle: async ({ request, fetch, locals }) => {
+		const id = (await request.formData()).get('articleId');
 		if (!id) {
 			return {
 				message: 'Id Not provided'
 			};
 		}
 
-		const deleteCategoryResponse = await fetch(CATEGORIES_URL + '/' + id, {
+		const deleteCategoryResponse = await fetch(ARTICLES_URL + '/' + id, {
 			method: 'delete'
 		});
 

--- a/src/routes/(dashboard)/dashboard/articles/+page.svelte
+++ b/src/routes/(dashboard)/dashboard/articles/+page.svelte
@@ -178,7 +178,7 @@
 				<Dialog.Description>Fill the nessesary fields :</Dialog.Description>
 			</Dialog.Header>
 			<form
-				action="?/createCategory"
+				action="?/createArticle"
 				method="post"
 				enctype="multipart/form-data"
 				use:enhance={() => {

--- a/src/routes/(dashboard)/dashboard/articles/data-table-articles-actions.svelte
+++ b/src/routes/(dashboard)/dashboard/articles/data-table-articles-actions.svelte
@@ -6,11 +6,13 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Trash } from '@lucide/svelte';
 	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
+
 	let { id }: { id: string } = $props();
+	let alertDialogOpen = $state(false);
 </script>
 
 {#snippet DeleteConfirm()}
-	<AlertDialog.Root>
+	<AlertDialog.Root bind:open={alertDialogOpen}>
 		<AlertDialog.Trigger class="hover:bg-muted hover:cursor-pointer">
 			<Trash size="16" class="text-destructive" />
 		</AlertDialog.Trigger>
@@ -18,14 +20,25 @@
 			<AlertDialog.Header>
 				<AlertDialog.Title>Are you sure?</AlertDialog.Title>
 				<AlertDialog.Description>
-					This action cannot be undone. This will permanently delete the category and remove the
-					data from our servers.
+					This action cannot be undone. This will permanently delete the article and remove the data
+					from our servers.
 				</AlertDialog.Description>
 			</AlertDialog.Header>
 			<AlertDialog.Footer>
 				<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-				<form action="?/deleteCategory" method="post" use:enhance>
-					<input type="hidden" name="categoryId" value={id} />
+				<form
+					action="?/deleteArticle"
+					method="post"
+					use:enhance={() => {
+						return async ({ result, update }) => {
+							if (result.type === 'success') {
+								alertDialogOpen = false;
+							}
+							await update();
+						};
+					}}
+				>
+					<input type="hidden" name="articleId" value={id} />
 					<AlertDialog.Action type="submit">Continue</AlertDialog.Action>
 				</form>
 			</AlertDialog.Footer>
@@ -49,7 +62,7 @@
 			<DropdownMenu.Group>
 				<DropdownMenu.Label>Actions</DropdownMenu.Label>
 				<DropdownMenu.Item onclick={() => navigator.clipboard.writeText(id)}>
-					Copy Category ID
+					Copy Article ID
 				</DropdownMenu.Item>
 			</DropdownMenu.Group>
 			<DropdownMenu.Separator />
@@ -60,7 +73,7 @@
 			</button>
 		</form> -->
 
-			<DropdownMenu.Item>View Category details</DropdownMenu.Item>
+			<DropdownMenu.Item>View Article details</DropdownMenu.Item>
 		</DropdownMenu.Content>
 	</DropdownMenu.Root>
 </div>

--- a/src/routes/(dashboard)/dashboard/categories/data-table-categories-actions.svelte
+++ b/src/routes/(dashboard)/dashboard/categories/data-table-categories-actions.svelte
@@ -6,11 +6,13 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Trash } from '@lucide/svelte';
 	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
+
 	let { id }: { id: string } = $props();
+	let alertDialogOpen = $state(false);
 </script>
 
 {#snippet DeleteConfirm()}
-	<AlertDialog.Root>
+	<AlertDialog.Root bind:open={alertDialogOpen}>
 		<AlertDialog.Trigger class="hover:bg-muted hover:cursor-pointer">
 			<Trash size="16" class="text-destructive" />
 		</AlertDialog.Trigger>
@@ -24,7 +26,18 @@
 			</AlertDialog.Header>
 			<AlertDialog.Footer>
 				<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-				<form action="?/deleteCategory" method="post" use:enhance>
+				<form
+					action="?/deleteCategory"
+					method="post"
+					use:enhance={() => {
+						return async ({ result, update }) => {
+							if (result.type === 'success') {
+								alertDialogOpen = false;
+							}
+							await update();
+						};
+					}}
+				>
 					<input type="hidden" name="categoryId" value={id} />
 					<AlertDialog.Action type="submit">Continue</AlertDialog.Action>
 				</form>


### PR DESCRIPTION
This pull request refactors the articles and categories management functionality in the dashboard. It primarily focuses on renaming and adapting actions and UI elements related to articles, while also introducing state binding for alert dialogs. Below is a breakdown of the most significant changes:

### Refactoring Articles Management

* Renamed the `createCategory` and `deleteCategory` actions to `createArticle` and `deleteArticle`, respectively, in `src/routes/(dashboard)/dashboard/articles/+page.server.ts`. Updated the corresponding API endpoint from `CATEGORIES_URL` to `ARTICLES_URL` for both actions. [[1]](diffhunk://#diff-8edfd6b0266c8a87b8d3ebe250e335a577007803192fb88f82b3e4df4c9ee77fL14-R13) [[2]](diffhunk://#diff-8edfd6b0266c8a87b8d3ebe250e335a577007803192fb88f82b3e4df4c9ee77fL40-R39) [[3]](diffhunk://#diff-8edfd6b0266c8a87b8d3ebe250e335a577007803192fb88f82b3e4df4c9ee77fL54-R61)
* Updated the form action in `src/routes/(dashboard)/dashboard/articles/+page.svelte` to use `createArticle` instead of `createCategory`.

### UI Adjustments for Articles

* Updated the `data-table-articles-actions.svelte` file to:
  - Bind the `alertDialogOpen` state to the `AlertDialog.Root` component for better dialog state management.
  - Update the deletion confirmation dialog to reflect "article" instead of "category" and added logic to close the dialog upon successful deletion.
  - Replace "Copy Category ID" and "View Category details" with "Copy Article ID" and "View Article details" in the dropdown menu. [[1]](diffhunk://#diff-4c3bbd8748bd0da8a99acd72e9012dd3811b2ce30aa18dc0547ee2cc9519fa64L52-R65) [[2]](diffhunk://#diff-4c3bbd8748bd0da8a99acd72e9012dd3811b2ce30aa18dc0547ee2cc9519fa64L63-R76)

### Enhancements to Categories Management

* Introduced state binding for the `AlertDialog.Root` component in `data-table-categories-actions.svelte` to manage dialog visibility. Added logic to close the dialog upon successful deletion of a category. [[1]](diffhunk://#diff-d412bd94bd890e4b36a50fa440764fec1a28a0e4e0719be98c21ee880a3fd781R9-R15) [[2]](diffhunk://#diff-d412bd94bd890e4b36a50fa440764fec1a28a0e4e0719be98c21ee880a3fd781L27-R40)…e instead of category