### PR TITLE
feat: implement rich text editor component and demo page

### DIFF
--- a/src/lib/components/editor/index.ts
+++ b/src/lib/components/editor/index.ts
@@ -1,0 +1,1 @@
+export { default as RichTextEditor } from './rich-text-editor.svelte';

--- a/src/lib/components/editor/rich-text-editor.svelte
+++ b/src/lib/components/editor/rich-text-editor.svelte
@@ -1,0 +1,845 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
+	import {
+		Bold,
+		Italic,
+		Underline,
+		Strikethrough,
+		AlignLeft,
+		AlignCenter,
+		AlignRight,
+		List,
+		ListOrdered,
+		Quote,
+		Code,
+		Code2,
+		Link,
+		Image,
+		Undo,
+		Redo,
+		Type,
+		Heading1,
+		Heading2,
+		Heading3,
+		MoreHorizontal
+	} from '@lucide/svelte';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+
+	export let content: string = '';
+	export let placeholder: string = 'Start writing your content...';
+	export let readonly: boolean = false;
+	export let minHeight: string = '300px';
+
+	let editor: HTMLDivElement;
+	let linkDialogOpen = false;
+	let imageDialogOpen = false;
+	let linkUrl = '';
+	let linkText = '';
+	let imageUrl = '';
+	let imageAlt = '';
+
+	// Active states for toolbar buttons
+	let activeBold = false;
+	let activeItalic = false;
+	let activeUnderline = false;
+	let activeStrikethrough = false;
+	let activeAlignLeft = false;
+	let activeAlignCenter = false;
+	let activeAlignRight = false;
+	let activeBulletList = false;
+	let activeNumberedList = false;
+	let currentBlockFormat = 'p';
+
+	onMount(() => {
+		if (editor) {
+			editor.innerHTML = content;
+
+			// Set up event listeners
+			editor.addEventListener('input', handleInput);
+			editor.addEventListener('paste', handlePaste);
+			editor.addEventListener('keydown', handleKeydown);
+			editor.addEventListener('mouseup', updateToolbarState);
+			editor.addEventListener('keyup', updateToolbarState);
+			editor.addEventListener('focus', updateToolbarState);
+			editor.addEventListener('selectionchange', updateToolbarState);
+
+			// Also listen to document selection change
+			document.addEventListener('selectionchange', updateToolbarState);
+
+			// Initial toolbar state update
+			setTimeout(updateToolbarState, 100);
+		}
+	});
+
+	function handleInput() {
+		content = editor.innerHTML;
+		updateToolbarState();
+	}
+
+	function handlePaste(e: ClipboardEvent) {
+		e.preventDefault();
+		const text = e.clipboardData?.getData('text/plain') || '';
+		document.execCommand('insertText', false, text);
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		// Handle keyboard shortcuts
+		if (e.ctrlKey || e.metaKey) {
+			switch (e.key) {
+				case 'b':
+					e.preventDefault();
+					execCommand('bold');
+					break;
+				case 'i':
+					e.preventDefault();
+					execCommand('italic');
+					break;
+				case 'u':
+					e.preventDefault();
+					execCommand('underline');
+					break;
+				case 'z':
+					e.preventDefault();
+					if (e.shiftKey) {
+						execCommand('redo');
+					} else {
+						execCommand('undo');
+					}
+					break;
+			}
+		}
+
+		// Handle Enter key for better list formatting
+		if (e.key === 'Enter') {
+			const selection = window.getSelection();
+			if (selection && selection.rangeCount > 0) {
+				const range = selection.getRangeAt(0);
+				const listItem = range.startContainer.parentElement?.closest('li');
+				if (listItem && listItem.textContent?.trim() === '') {
+					e.preventDefault();
+					execCommand('outdent');
+				}
+			}
+		}
+	}
+
+	function execCommand(command: string, value?: string) {
+		if (typeof document === 'undefined') return;
+		document.execCommand(command, false, value);
+		if (editor) {
+			editor.focus();
+			// Update toolbar state after command execution
+			setTimeout(updateToolbarState, 10);
+		}
+	}
+
+	function formatBlock(tag: string) {
+		if (typeof document === 'undefined') return;
+		document.execCommand('formatBlock', false, tag);
+		if (editor) {
+			editor.focus();
+			// Update toolbar state after command execution
+			setTimeout(updateToolbarState, 10);
+		}
+	}
+
+	function insertLink() {
+		if (typeof window === 'undefined') return;
+		const selection = window.getSelection();
+		if (selection && selection.toString()) {
+			linkText = selection.toString();
+		}
+		linkDialogOpen = true;
+	}
+
+	function applyLink() {
+		if (linkUrl && typeof document !== 'undefined') {
+			if (linkText) {
+				const html = `<a href="${linkUrl}" target="_blank" rel="noopener noreferrer">${linkText}</a>`;
+				document.execCommand('insertHTML', false, html);
+			} else {
+				document.execCommand('createLink', false, linkUrl);
+			}
+		}
+		linkDialogOpen = false;
+		linkUrl = '';
+		linkText = '';
+		editor.focus();
+	}
+
+	function insertImage() {
+		if (typeof window === 'undefined') return;
+
+		// If there's selected text, use it as alt text
+		const selection = window.getSelection();
+		if (selection && selection.toString().trim()) {
+			imageAlt = selection.toString().trim();
+		}
+
+		imageDialogOpen = true;
+	}
+
+	function applyImage() {
+		// Validate inputs
+		if (!imageUrl.trim() || typeof document === 'undefined' || !editor) {
+			return;
+		}
+
+		// Focus the editor first to ensure we have an active selection
+		editor.focus();
+
+		// Create the image HTML with better styling
+		const cleanImageUrl = imageUrl.trim();
+		const cleanImageAlt = imageAlt.trim() || 'Image';
+		const html = `<img src="${cleanImageUrl}" alt="${cleanImageAlt}" style="max-width: 100%; height: auto; margin: 10px 0; display: block;" />`;
+
+		// Use insertHTML to insert the image
+		const success = document.execCommand('insertHTML', false, html);
+
+		// Fallback method if insertHTML doesn't work
+		if (!success) {
+			try {
+				const selection = window.getSelection();
+				if (selection && selection.rangeCount > 0) {
+					const range = selection.getRangeAt(0);
+					range.deleteContents();
+
+					const img = document.createElement('img');
+					img.src = cleanImageUrl;
+					img.alt = cleanImageAlt;
+					img.style.maxWidth = '100%';
+					img.style.height = 'auto';
+					img.style.margin = '10px 0';
+					img.style.display = 'block';
+
+					range.insertNode(img);
+
+					// Move cursor after the image
+					const newRange = document.createRange();
+					newRange.setStartAfter(img);
+					newRange.collapse(true);
+					selection.removeAllRanges();
+					selection.addRange(newRange);
+				}
+			} catch (error) {
+				console.error('Error inserting image:', error);
+			}
+		}
+
+		// Update content and trigger input event
+		content = editor.innerHTML;
+		editor.dispatchEvent(new Event('input', { bubbles: true }));
+
+		// Close dialog and reset values
+		imageDialogOpen = false;
+		imageUrl = '';
+		imageAlt = '';
+
+		// Ensure editor stays focused
+		if (editor) {
+			editor.focus();
+		}
+	}
+
+	function isCommandActive(command: string): boolean {
+		if (typeof document === 'undefined') return false;
+		try {
+			return document.queryCommandState(command);
+		} catch {
+			return false;
+		}
+	}
+
+	function updateToolbarState() {
+		if (typeof document === 'undefined' || !editor) return;
+
+		// Check if editor is focused or contains the selection
+		const selection = window.getSelection();
+		if (!selection || selection.rangeCount === 0) return;
+
+		const range = selection.getRangeAt(0);
+		if (
+			!editor.contains(range.commonAncestorContainer) &&
+			range.commonAncestorContainer !== editor
+		) {
+			return;
+		}
+
+		try {
+			activeBold = document.queryCommandState('bold');
+			activeItalic = document.queryCommandState('italic');
+			activeUnderline = document.queryCommandState('underline');
+			activeStrikethrough = document.queryCommandState('strikeThrough');
+			activeAlignLeft = document.queryCommandState('justifyLeft');
+			activeAlignCenter = document.queryCommandState('justifyCenter');
+			activeAlignRight = document.queryCommandState('justifyRight');
+			activeBulletList = document.queryCommandState('insertUnorderedList');
+			activeNumberedList = document.queryCommandState('insertOrderedList');
+
+			// Update current block format
+			currentBlockFormat = getCurrentBlockFormat();
+
+			console.log('Toolbar updated:', {
+				bold: activeBold,
+				italic: activeItalic,
+				format: currentBlockFormat
+			});
+		} catch (error) {
+			console.log('Error updating toolbar:', error);
+			// Reset all states if there's an error
+			activeBold = false;
+			activeItalic = false;
+			activeUnderline = false;
+			activeStrikethrough = false;
+			activeAlignLeft = false;
+			activeAlignCenter = false;
+			activeAlignRight = false;
+			activeBulletList = false;
+			activeNumberedList = false;
+			currentBlockFormat = 'p';
+		}
+	}
+
+	function getCurrentBlockFormat(): string {
+		if (typeof window === 'undefined') return 'p';
+
+		try {
+			const selection = window.getSelection();
+			if (!selection || selection.rangeCount === 0) return 'p';
+
+			const range = selection.getRangeAt(0);
+			let element =
+				range.startContainer.nodeType === Node.TEXT_NODE
+					? range.startContainer.parentElement
+					: (range.startContainer as Element);
+
+			// Walk up the DOM tree to find a block-level element
+			while (element && element !== editor && element.parentElement) {
+				const tagName = element.tagName?.toLowerCase();
+				if (['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div', 'blockquote'].includes(tagName)) {
+					return tagName;
+				}
+				element = element.parentElement;
+			}
+		} catch (error) {
+			console.log('Error getting block format:', error);
+		}
+
+		return 'p';
+	}
+
+	$: if (editor && content !== editor.innerHTML) {
+		editor.innerHTML = content;
+	}
+</script>
+
+<div class="rich-text-editor bg-background overflow-hidden rounded-lg border">
+	<!-- Toolbar -->
+	<div class="bg-muted/30 border-b p-2">
+		<div class="flex flex-wrap items-center gap-1">
+			<!-- Text Formatting Group -->
+			<div class="flex items-center gap-1">
+				<Button
+					variant={activeBold ? 'default' : 'ghost'}
+					size="sm"
+					onclick={() => execCommand('bold')}
+					disabled={readonly}
+					title="Bold (Ctrl+B)"
+					class={activeBold
+						? '!bg-primary !text-primary-foreground hover:!bg-primary/90'
+						: 'hover:bg-muted'}
+				>
+					<Bold class="h-4 w-4" />
+				</Button>
+				<Button
+					variant={activeItalic ? 'default' : 'ghost'}
+					size="sm"
+					onclick={() => execCommand('italic')}
+					disabled={readonly}
+					title="Italic (Ctrl+I)"
+					class={activeItalic
+						? '!bg-primary !text-primary-foreground hover:!bg-primary/90'
+						: 'hover:bg-muted'}
+				>
+					<Italic class="h-4 w-4" />
+				</Button>
+				<Button
+					variant={activeUnderline ? 'default' : 'ghost'}
+					size="sm"
+					onclick={() => execCommand('underline')}
+					disabled={readonly}
+					title="Underline (Ctrl+U)"
+					class={activeUnderline
+						? '!bg-primary !text-primary-foreground hover:!bg-primary/90'
+						: 'hover:bg-muted'}
+				>
+					<Underline class="h-4 w-4" />
+				</Button>
+				<Button
+					variant={activeStrikethrough ? 'default' : 'ghost'}
+					size="sm"
+					onclick={() => execCommand('strikeThrough')}
+					disabled={readonly}
+					title="Strikethrough"
+					class={activeStrikethrough
+						? '!bg-primary !text-primary-foreground hover:!bg-primary/90'
+						: 'hover:bg-muted'}
+				>
+					<Strikethrough class="h-4 w-4" />
+				</Button>
+			</div>
+
+			<Separator orientation="vertical" class="h-6" />
+
+			<!-- Heading Dropdown -->
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger>
+					<Button
+						variant={currentBlockFormat !== 'p' ? 'default' : 'ghost'}
+						size="sm"
+						disabled={readonly}
+						class={currentBlockFormat !== 'p'
+							? '!bg-primary !text-primary-foreground hover:!bg-primary/90'
+							: 'hover:bg-muted'}
+					>
+						{#if currentBlockFormat === 'h1'}
+							<Heading1 class="h-4 w-4" />
+						{:else if currentBlockFormat === 'h2'}
+							<Heading2 class="h-4 w-4" />
+						{:else if currentBlockFormat === 'h3'}
+							<Heading3 class="h-4 w-4" />
+						{:else}
+							<Type class="h-4 w-4" />
+						{/if}
+					</Button>
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Content>
+					<DropdownMenu.Item
+						onclick={() => formatBlock('p')}
+						class={currentBlockFormat === 'p' ? 'bg-muted' : ''}
+					>
+						<Type class="mr-2 h-4 w-4" />
+						Normal Text
+					</DropdownMenu.Item>
+					<DropdownMenu.Item
+						onclick={() => formatBlock('h1')}
+						class={currentBlockFormat === 'h1' ? 'bg-muted' : ''}
+					>
+						<Heading1 class="mr-2 h-4 w-4" />
+						Heading 1
+					</DropdownMenu.Item>
+					<DropdownMenu.Item
+						onclick={() => formatBlock('h2')}
+						class={currentBlockFormat === 'h2' ? 'bg-muted' : ''}
+					>
+						<Heading2 class="mr-2 h-4 w-4" />
+						Heading 2
+					</DropdownMenu.Item>
+					<DropdownMenu.Item
+						onclick={() => formatBlock('h3')}
+						class={currentBlockFormat === 'h3' ? 'bg-muted' : ''}
+					>
+						<Heading3 class="mr-2 h-4 w-4" />
+						Heading 3
+					</DropdownMenu.Item>
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
+
+			<Separator orientation="vertical" class="h-6" />
+
+			<!-- Alignment Group -->
+			<div class="flex items-center gap-1">
+				<Button
+					variant={activeAlignLeft ? 'default' : 'ghost'}
+					size="sm"
+					onclick={() => execCommand('justifyLeft')}
+					disabled={readonly}
+					title="Align Left"
+					class={activeAlignLeft
+						? '!bg-primary !text-primary-foreground hover:!bg-primary/90'
+						: 'hover:bg-muted'}
+				>
+					<AlignLeft class="h-4 w-4" />
+				</Button>
+				<Button
+					variant={activeAlignCenter ? 'default' : 'ghost'}
+					size="sm"
+					onclick={() => execCommand('justifyCenter')}
+					disabled={readonly}
+					title="Align Center"
+					class={activeAlignCenter
+						? '!bg-primary !text-primary-foreground hover:!bg-primary/90'
+						: 'hover:bg-muted'}
+				>
+					<AlignCenter class="h-4 w-4" />
+				</Button>
+				<Button
+					variant={activeAlignRight ? 'default' : 'ghost'}
+					size="sm"
+					onclick={() => execCommand('justifyRight')}
+					disabled={readonly}
+					title="Align Right"
+					class={activeAlignRight
+						? '!bg-primary !text-primary-foreground hover:!bg-primary/90'
+						: 'hover:bg-muted'}
+				>
+					<AlignRight class="h-4 w-4" />
+				</Button>
+			</div>
+
+			<Separator orientation="vertical" class="h-6" />
+
+			<!-- Lists Group -->
+			<div class="flex items-center gap-1">
+				<Button
+					variant={activeBulletList ? 'default' : 'ghost'}
+					size="sm"
+					onclick={() => execCommand('insertUnorderedList')}
+					disabled={readonly}
+					title="Bullet List"
+					class={activeBulletList
+						? '!bg-primary !text-primary-foreground hover:!bg-primary/90'
+						: 'hover:bg-muted'}
+				>
+					<List class="h-4 w-4" />
+				</Button>
+				<Button
+					variant={activeNumberedList ? 'default' : 'ghost'}
+					size="sm"
+					onclick={() => execCommand('insertOrderedList')}
+					disabled={readonly}
+					title="Numbered List"
+					class={activeNumberedList
+						? '!bg-primary !text-primary-foreground hover:!bg-primary/90'
+						: 'hover:bg-muted'}
+				>
+					<ListOrdered class="h-4 w-4" />
+				</Button>
+				<Button
+					variant="ghost"
+					size="sm"
+					onclick={() => formatBlock('blockquote')}
+					disabled={readonly}
+					title="Quote"
+					class="hover:bg-muted"
+				>
+					<Quote class="h-4 w-4" />
+				</Button>
+			</div>
+
+			<Separator orientation="vertical" class="h-6" />
+
+			<!-- Insert Group -->
+			<div class="flex items-center gap-1">
+				<Button
+					variant="ghost"
+					size="sm"
+					onclick={insertLink}
+					disabled={readonly}
+					title="Insert Link"
+				>
+					<Link class="h-4 w-4" />
+				</Button>
+				<Button
+					variant="ghost"
+					size="sm"
+					onclick={insertImage}
+					disabled={readonly}
+					title="Insert Image"
+				>
+					<Image class="h-4 w-4" />
+				</Button>
+				<Button
+					variant="ghost"
+					size="sm"
+					onclick={() => execCommand('insertHTML', '<hr>')}
+					disabled={readonly}
+					title="Insert Horizontal Rule"
+				>
+					<MoreHorizontal class="h-4 w-4" />
+				</Button>
+			</div>
+
+			<Separator orientation="vertical" class="h-6" />
+
+			<!-- Code Group -->
+			<div class="flex items-center gap-1">
+				<Button
+					variant="ghost"
+					size="sm"
+					onclick={() => execCommand('insertHTML', '<code></code>')}
+					disabled={readonly}
+					title="Inline Code"
+				>
+					<Code class="h-4 w-4" />
+				</Button>
+				<Button
+					variant="ghost"
+					size="sm"
+					onclick={() => execCommand('insertHTML', '<pre><code></code></pre>')}
+					disabled={readonly}
+					title="Code Block"
+				>
+					<Code2 class="h-4 w-4" />
+				</Button>
+			</div>
+
+			<Separator orientation="vertical" class="h-6" />
+
+			<!-- Undo/Redo Group -->
+			<div class="flex items-center gap-1">
+				<Button
+					variant="ghost"
+					size="sm"
+					onclick={() => execCommand('undo')}
+					disabled={readonly}
+					title="Undo (Ctrl+Z)"
+				>
+					<Undo class="h-4 w-4" />
+				</Button>
+				<Button
+					variant="ghost"
+					size="sm"
+					onclick={() => execCommand('redo')}
+					disabled={readonly}
+					title="Redo (Ctrl+Shift+Z)"
+				>
+					<Redo class="h-4 w-4" />
+				</Button>
+			</div>
+		</div>
+	</div>
+
+	<!-- Editor Content -->
+	<div
+		bind:this={editor}
+		contenteditable={!readonly}
+		class="prose prose-sm editor-content max-w-none p-4 focus:outline-none"
+		style="min-height: {minHeight};"
+		data-placeholder={placeholder}
+		role="textbox"
+		aria-label="Rich text editor"
+	></div>
+</div>
+
+<!-- Link Dialog -->
+<Dialog.Root bind:open={linkDialogOpen}>
+	<Dialog.Content class="sm:max-w-md">
+		<Dialog.Header>
+			<Dialog.Title>Insert Link</Dialog.Title>
+			<Dialog.Description>Add a link to your content</Dialog.Description>
+		</Dialog.Header>
+		<div class="grid gap-4 py-4">
+			<div class="grid gap-2">
+				<Label for="link-url">URL</Label>
+				<Input id="link-url" bind:value={linkUrl} placeholder="https://example.com" type="url" />
+			</div>
+			<div class="grid gap-2">
+				<Label for="link-text">Link Text (optional)</Label>
+				<Input id="link-text" bind:value={linkText} placeholder="Link text" />
+			</div>
+		</div>
+		<Dialog.Footer>
+			<Button variant="outline" onclick={() => (linkDialogOpen = false)}>Cancel</Button>
+			<Button onclick={applyLink}>Insert Link</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>
+
+<!-- Image Dialog -->
+<Dialog.Root bind:open={imageDialogOpen}>
+	<Dialog.Content class="sm:max-w-md">
+		<Dialog.Header>
+			<Dialog.Title>Insert Image</Dialog.Title>
+			<Dialog.Description>Add an image to your content</Dialog.Description>
+		</Dialog.Header>
+		<div class="grid gap-4 py-4">
+			<div class="grid gap-2">
+				<Label for="image-url">Image URL</Label>
+				<Input
+					id="image-url"
+					bind:value={imageUrl}
+					placeholder="https://example.com/image.jpg"
+					type="url"
+				/>
+			</div>
+			<div class="grid gap-2">
+				<Label for="image-alt">Alt Text</Label>
+				<Input id="image-alt" bind:value={imageAlt} placeholder="Description of the image" />
+			</div>
+		</div>
+		<Dialog.Footer>
+			<Button variant="outline" onclick={() => (imageDialogOpen = false)}>Cancel</Button>
+			<Button onclick={applyImage} disabled={!imageUrl.trim()}>Insert Image</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>
+
+<style>
+	.rich-text-editor [contenteditable]:empty:before {
+		content: attr(data-placeholder);
+		color: hsl(var(--muted-foreground));
+		pointer-events: none;
+	}
+
+	/* Enhanced active button styles using primary theme color */
+	.rich-text-editor :global(.bg-primary) {
+		background-color: hsl(var(--primary)) !important;
+		color: hsl(var(--primary-foreground)) !important;
+		transition: all 0.2s ease-in-out;
+	}
+
+	.rich-text-editor :global(.bg-primary:hover) {
+		background-color: hsl(var(--primary) / 0.9) !important;
+	}
+
+	.rich-text-editor :global(.prose) {
+		color: hsl(var(--foreground));
+	}
+
+	.rich-text-editor :global(.prose h1) {
+		font-size: 2rem;
+		font-weight: 700;
+		line-height: 2.5rem;
+		margin: 1rem 0 0.5rem 0;
+	}
+
+	.rich-text-editor :global(.prose h2) {
+		font-size: 1.5rem;
+		font-weight: 600;
+		line-height: 2rem;
+		margin: 0.875rem 0 0.5rem 0;
+	}
+
+	.rich-text-editor :global(.prose h3) {
+		font-size: 1.25rem;
+		font-weight: 600;
+		line-height: 1.75rem;
+		margin: 0.75rem 0 0.5rem 0;
+	}
+
+	.rich-text-editor :global(.prose p) {
+		margin: 0.5rem 0;
+		line-height: 1.6;
+	}
+
+	.rich-text-editor :global(.prose ul),
+	.rich-text-editor :global(.prose ol) {
+		margin: 0.5rem 0;
+		padding-left: 1.5rem;
+	}
+
+	.rich-text-editor :global(.prose ul) {
+		list-style-type: disc;
+	}
+
+	.rich-text-editor :global(.prose ol) {
+		list-style-type: decimal;
+	}
+
+	.rich-text-editor :global(.prose li) {
+		margin: 0.25rem 0;
+		display: list-item;
+	}
+
+	.rich-text-editor :global(.prose ul li) {
+		list-style-type: disc;
+	}
+
+	.rich-text-editor :global(.prose ol li) {
+		list-style-type: decimal;
+	}
+
+	/* Ensure lists display properly in contenteditable */
+	.rich-text-editor :global(.editor-content ul) {
+		list-style-type: disc !important;
+		padding-left: 1.5rem !important;
+		margin: 0.5rem 0 !important;
+	}
+
+	.rich-text-editor :global(.editor-content ol) {
+		list-style-type: decimal !important;
+		padding-left: 1.5rem !important;
+		margin: 0.5rem 0 !important;
+	}
+
+	.rich-text-editor :global(.editor-content li) {
+		display: list-item !important;
+		margin: 0.25rem 0 !important;
+		list-style-position: outside !important;
+	}
+
+	.rich-text-editor :global(.editor-content ul li) {
+		list-style-type: disc !important;
+	}
+
+	.rich-text-editor :global(.editor-content ol li) {
+		list-style-type: decimal !important;
+	}
+
+	.rich-text-editor :global(.prose blockquote) {
+		border-left: 4px solid hsl(var(--primary));
+		padding-left: 1rem;
+		margin: 1rem 0;
+		font-style: italic;
+		color: hsl(var(--muted-foreground));
+	}
+
+	.rich-text-editor :global(.prose code) {
+		background: hsl(var(--muted));
+		padding: 0.125rem 0.25rem;
+		border-radius: 0.25rem;
+		font-size: 0.875rem;
+		font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+	}
+
+	.rich-text-editor :global(.prose pre) {
+		background: hsl(var(--muted));
+		padding: 1rem;
+		border-radius: 0.5rem;
+		overflow-x: auto;
+		margin: 1rem 0;
+	}
+
+	.rich-text-editor :global(.prose pre code) {
+		background: none;
+		padding: 0;
+	}
+
+	.rich-text-editor :global(.prose a) {
+		color: hsl(var(--primary));
+		text-decoration: underline;
+	}
+
+	.rich-text-editor :global(.prose a:hover) {
+		color: hsl(var(--primary) / 0.8);
+	}
+
+	.rich-text-editor :global(.prose hr) {
+		border: none;
+		border-top: 1px solid hsl(var(--border));
+		margin: 2rem 0;
+	}
+
+	.rich-text-editor :global(.prose img),
+	.rich-text-editor :global(.editor-content img) {
+		border-radius: 0.5rem;
+		box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+		max-width: 100%;
+		height: auto;
+		margin: 10px 0;
+		display: block;
+		cursor: pointer;
+		transition: transform 0.2s ease-in-out;
+	}
+
+	.rich-text-editor :global(.prose img:hover),
+	.rich-text-editor :global(.editor-content img:hover) {
+		transform: scale(1.02);
+	}
+</style>

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -119,7 +119,7 @@
 
 <div class="from-background via-background to-muted/20 min-h-screen bg-gradient-to-br">
 	<!-- Hero Section -->
-	<section class="relative py-16 pt-32">
+	<section class="relative py-16 pt-16">
 		<div class="bg-grid-white/[0.02] absolute inset-0 bg-[size:60px_60px]"></div>
 		<div class="relative container mx-auto px-4">
 			<div class="mx-auto max-w-3xl text-center">

--- a/src/routes/(app)/editor-demo/+page.svelte
+++ b/src/routes/(app)/editor-demo/+page.svelte
@@ -1,0 +1,271 @@
+<script lang="ts">
+	import { RichTextEditor } from '$lib/components/editor';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
+	import { Save, Eye, FileText } from '@lucide/svelte';
+
+	let editorContent = `
+		<h1>Welcome to the Rich Text Editor</h1>
+		<p>This is a powerful rich text editor built for the blog application. You can format text, add links, images, and much more!</p>
+		
+		<h2>Features</h2>
+		<ul>
+			<li><strong>Text Formatting</strong>: Bold, italic, underline, strikethrough</li>
+			<li><strong>Headings</strong>: H1, H2, H3 support</li>
+			<li><strong>Lists</strong>: Bullet and numbered lists</li>
+			<li><strong>Links & Images</strong>: Easy insertion with dialogs</li>
+			<li><strong>Code</strong>: Inline code and code blocks</li>
+		</ul>
+		
+		<blockquote>
+			"A great editor makes writing a pleasure, not a chore."
+		</blockquote>
+		
+		<h3>Try it out!</h3>
+		<p>Start editing and see the magic happen. Use the toolbar above or keyboard shortcuts like <code>Ctrl+B</code> for bold and <code>Ctrl+I</code> for italic.</p>
+	`;
+
+	let articleTitle = 'My Amazing Blog Post';
+	let articleTags = 'svelte, rich-text, editor';
+	let previewMode = false;
+
+	function saveArticle() {
+		console.log('Saving article:', {
+			title: articleTitle,
+			content: editorContent,
+			tags: articleTags.split(',').map((tag) => tag.trim())
+		});
+		// Here you would typically send this to your API
+		alert('Article saved! (Check console for data)');
+	}
+
+	function togglePreview() {
+		previewMode = !previewMode;
+	}
+</script>
+
+<svelte:head>
+	<title>Rich Text Editor Demo - Blog App</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-6xl px-4 py-8">
+	<div class="mb-8">
+		<h1 class="mb-2 text-4xl font-bold tracking-tight">Rich Text Editor Demo</h1>
+		<p class="text-muted-foreground text-lg">
+			Experience the power of our modern rich text editor designed for blog writing.
+		</p>
+	</div>
+
+	<div class="grid gap-8 lg:grid-cols-12">
+		<!-- Editor Panel -->
+		<div class="lg:col-span-8">
+			<Card.Root>
+				<Card.Header>
+					<div class="flex items-center justify-between">
+						<Card.Title class="flex items-center gap-2">
+							<FileText class="h-5 w-5" />
+							{previewMode ? 'Article Preview' : 'Write Article'}
+						</Card.Title>
+						<div class="flex items-center gap-2">
+							<Button variant="outline" size="sm" onclick={togglePreview}>
+								<Eye class="mr-2 h-4 w-4" />
+								{previewMode ? 'Edit' : 'Preview'}
+							</Button>
+							<Button size="sm" onclick={saveArticle}>
+								<Save class="mr-2 h-4 w-4" />
+								Save
+							</Button>
+						</div>
+					</div>
+				</Card.Header>
+				<Card.Content class="p-6">
+					<div class="space-y-4">
+						<!-- Article Title -->
+						<div class="space-y-2">
+							<Label for="title">Article Title</Label>
+							<Input
+								id="title"
+								bind:value={articleTitle}
+								placeholder="Enter your article title..."
+								class="text-lg font-semibold"
+								disabled={previewMode}
+							/>
+						</div>
+
+						<!-- Tags -->
+						<div class="space-y-2">
+							<Label for="tags">Tags (comma-separated)</Label>
+							<Input
+								id="tags"
+								bind:value={articleTags}
+								placeholder="svelte, javascript, tutorial"
+								disabled={previewMode}
+							/>
+						</div>
+
+						<Separator />
+
+						<!-- Editor or Preview -->
+						{#if previewMode}
+							<div class="prose prose-sm min-h-[400px] max-w-none rounded-lg border p-4">
+								<h1 class="mb-4 text-3xl font-bold">{articleTitle}</h1>
+								<div class="mb-6 flex flex-wrap gap-2">
+									{#each articleTags.split(',') as tag}
+										{#if tag.trim()}
+											<Badge variant="secondary">{tag.trim()}</Badge>
+										{/if}
+									{/each}
+								</div>
+								{@html editorContent}
+							</div>
+						{:else}
+							<RichTextEditor
+								bind:content={editorContent}
+								placeholder="Start writing your amazing article..."
+								minHeight="400px"
+							/>
+						{/if}
+					</div>
+				</Card.Content>
+			</Card.Root>
+		</div>
+
+		<!-- Sidebar -->
+		<div class="space-y-6 lg:col-span-4">
+			<!-- Writing Tips -->
+			<Card.Root>
+				<Card.Header>
+					<Card.Title class="text-lg">✨ Writing Tips</Card.Title>
+				</Card.Header>
+				<Card.Content class="space-y-3 text-sm">
+					<div>
+						<strong>Keyboard Shortcuts:</strong>
+						<ul class="text-muted-foreground mt-1 space-y-1">
+							<li>• <code>Ctrl+B</code> - Bold</li>
+							<li>• <code>Ctrl+I</code> - Italic</li>
+							<li>• <code>Ctrl+U</code> - Underline</li>
+							<li>• <code>Ctrl+Z</code> - Undo</li>
+							<li>• <code>Ctrl+Shift+Z</code> - Redo</li>
+						</ul>
+					</div>
+					<Separator />
+					<div>
+						<strong>Best Practices:</strong>
+						<ul class="text-muted-foreground mt-1 space-y-1">
+							<li>• Use headings to structure content</li>
+							<li>• Keep paragraphs concise</li>
+							<li>• Add alt text to images</li>
+							<li>• Use lists for better readability</li>
+						</ul>
+					</div>
+				</Card.Content>
+			</Card.Root>
+
+			<!-- Editor Features -->
+			<Card.Root>
+				<Card.Header>
+					<Card.Title class="text-lg">🚀 Editor Features</Card.Title>
+				</Card.Header>
+				<Card.Content class="space-y-2 text-sm">
+					<div class="grid grid-cols-2 gap-2">
+						<Badge variant="outline" class="justify-center">Bold/Italic</Badge>
+						<Badge variant="outline" class="justify-center">Headings</Badge>
+						<Badge variant="outline" class="justify-center">Lists</Badge>
+						<Badge variant="outline" class="justify-center">Links</Badge>
+						<Badge variant="outline" class="justify-center">Images</Badge>
+						<Badge variant="outline" class="justify-center">Code</Badge>
+						<Badge variant="outline" class="justify-center">Quotes</Badge>
+						<Badge variant="outline" class="justify-center">Alignment</Badge>
+					</div>
+				</Card.Content>
+			</Card.Root>
+
+			<!-- Stats -->
+			<Card.Root>
+				<Card.Header>
+					<Card.Title class="text-lg">📊 Article Stats</Card.Title>
+				</Card.Header>
+				<Card.Content class="space-y-3">
+					<div class="flex justify-between">
+						<span class="text-muted-foreground text-sm">Characters:</span>
+						<span class="text-sm font-medium">{editorContent.replace(/<[^>]*>/g, '').length}</span>
+					</div>
+					<div class="flex justify-between">
+						<span class="text-muted-foreground text-sm">Words:</span>
+						<span class="text-sm font-medium"
+							>{editorContent
+								.replace(/<[^>]*>/g, '')
+								.split(/\s+/)
+								.filter((word) => word.length > 0).length}</span
+						>
+					</div>
+					<div class="flex justify-between">
+						<span class="text-muted-foreground text-sm">Tags:</span>
+						<span class="text-sm font-medium"
+							>{articleTags.split(',').filter((tag) => tag.trim()).length}</span
+						>
+					</div>
+				</Card.Content>
+			</Card.Root>
+		</div>
+	</div>
+</div>
+
+<style>
+	/* Custom styles for the preview */
+	:global(.prose h1) {
+		color: hsl(var(--foreground));
+		border-bottom: 2px solid hsl(var(--border));
+		padding-bottom: 0.5rem;
+	}
+
+	:global(.prose h2) {
+		color: hsl(var(--foreground));
+		margin-top: 2rem;
+	}
+
+	:global(.prose h3) {
+		color: hsl(var(--foreground));
+		margin-top: 1.5rem;
+	}
+
+	:global(.prose code) {
+		background: hsl(var(--muted));
+		color: hsl(var(--foreground));
+		padding: 0.125rem 0.25rem;
+		border-radius: 0.25rem;
+		font-size: 0.875rem;
+	}
+
+	:global(.prose blockquote) {
+		border-left: 4px solid hsl(var(--primary));
+		padding-left: 1rem;
+		margin: 1.5rem 0;
+		font-style: italic;
+		color: hsl(var(--muted-foreground));
+	}
+
+	:global(.prose ul),
+	:global(.prose ol) {
+		padding-left: 1.5rem;
+	}
+
+	:global(.prose li) {
+		margin: 0.5rem 0;
+	}
+
+	:global(.prose a) {
+		color: hsl(var(--primary));
+		text-decoration: underline;
+	}
+
+	:global(.prose img) {
+		border-radius: 0.5rem;
+		box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+		margin: 1rem 0;
+	}
+</style>


### PR DESCRIPTION
This pull request introduces a rich text editor feature for the blog application, along with UI enhancements and a minor adjustment to an existing page layout. The key changes include exporting the `RichTextEditor` component, integrating a new editor demo page, and refining the hero section's layout.

### Rich Text Editor Integration:
* [`src/lib/components/editor/index.ts`](diffhunk://#diff-e941ae15819507736e9f347ccc016feff4674325a36f6b1e04aaa7bc2d189c4eR1): Exported the `RichTextEditor` component to make it available for use across the application.
* [`src/routes/(app)/editor-demo/+page.svelte`](diffhunk://#diff-f4c2de48f449d10e65253e7b292bfd2138002560e1abad870f98a95eee1a4770R1-R271): Added a new demo page showcasing the `RichTextEditor` with features like text formatting, preview mode, and article saving. The page also includes a sidebar with writing tips, editor features, and article statistics.

### UI Enhancements:
* [`src/routes/(app)/+page.svelte`](diffhunk://#diff-4b17bace8c259b69442bea2c60f16389026e586a7f88267ff145c925af19ea12L122-R122): Adjusted the padding in the hero section (`pt-32` to `pt-16`) for improved visual balance.